### PR TITLE
Add client PDF viewing mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,16 +41,21 @@
         <div class="drop-zone" id="dropZone">
             <div class="drop-zone-content">
                 <h3>📏 DFR Calipers</h3>
-                <p>Drag & drop images or text files here</p> <p>or</p>
+                <p>Drag & drop images, text, or PDF files here</p> <p>or</p>
                 <button class="paste-btn" onclick="handlePaste()">Paste from Clipboard</button>
                 <p style="margin-top: 15px; font-size: 13px; color: #888;">Use 'i' button for instructions.</p>
                 <button class="btn browse-files-btn" onclick="document.getElementById('fileInput').click()">Browse Files</button>
             </div>
         </div>
         <div class="content-area" id="contentArea"></div>
+        <div class="pdf-controls" id="pdfControls">
+            <button class="btn action-red" onclick="prevPDFPage()">&#9664;</button>
+            <span id="pageIndicator">1 / 1</span>
+            <button class="btn action-red" onclick="nextPDFPage()">&#9654;</button>
+        </div>
     </div>
 
-    <input type="file" id="fileInput" class="file-input" accept="image/*,text/*" onchange="handleFileSelect(event)">
+    <input type="file" id="fileInput" class="file-input" accept="image/*,text/*,application/pdf" onchange="handleFileSelect(event)">
 
     <div id="instructionsModal" class="modal-overlay">
         <div class="modal-content-wrapper">
@@ -87,6 +92,7 @@
         <a href="https://profiles.stanford.edu/rogersaj" target="_blank" rel="noopener noreferrer">Built by A.J. Rogers, May 2025</a>
     </div>
 
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
     <script src="script.js"></script>
-</body>
+  </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -6,6 +6,13 @@ let currentColor = '#FF3B30';
         let dragTarget = null;
         let dragOffset = { x: 0, y: 0 };
 
+        let pdfDoc = null;
+        let currentPDFPage = 1;
+        let totalPDFPages = 0;
+        const pdfControls = document.getElementById('pdfControls');
+        const pageIndicator = document.getElementById('pageIndicator');
+        if (window['pdfjsLib']) pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js';
+
         const dropZone = document.getElementById('dropZone');
         const contentArea = document.getElementById('contentArea');
 
@@ -29,6 +36,9 @@ let currentColor = '#FF3B30';
             } else if (file.type.startsWith('text/')) {
                 reader.onload = ev => displayText(ev.target.result);
                 reader.readAsText(file);
+            } else if (file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf')) {
+                reader.onload = ev => displayPDF(ev.target.result);
+                reader.readAsArrayBuffer(file);
             }
         }
         function handleFileSelect(event) { if (event.target.files.length > 0) handleFiles(Array.from(event.target.files)); }
@@ -55,12 +65,56 @@ let currentColor = '#FF3B30';
             contentArea.innerHTML = `<button class="clear-content" onclick="clearContent()">× Clear Content</button><div class="pasted-text">${text.replace(/</g, "&lt;").replace(/>/g, "&gt;")}</div>`;
             showContent();
         }
+        function displayPDF(arrayBuffer) {
+            pdfjsLib.getDocument({ data: arrayBuffer }).promise.then(pdf => {
+                pdfDoc = pdf;
+                totalPDFPages = pdf.numPages;
+                currentPDFPage = 1;
+                renderPDFPage(currentPDFPage);
+                if (pdfControls) pdfControls.style.display = 'flex';
+            });
+        }
+        function renderPDFPage(num) {
+            if (!pdfDoc) return;
+            pdfDoc.getPage(num).then(page => {
+                const viewport = page.getViewport({ scale: 1.5 });
+                const canvas = document.createElement('canvas');
+                const ctx = canvas.getContext('2d');
+                canvas.height = viewport.height;
+                canvas.width = viewport.width;
+                page.render({ canvasContext: ctx, viewport: viewport }).promise.then(() => {
+                    const imgData = canvas.toDataURL('image/png');
+                    displayImage(imgData);
+                    updatePDFPageIndicator();
+                    clearAllCalipers();
+                });
+            });
+        }
+        function nextPDFPage() {
+            if (currentPDFPage < totalPDFPages) {
+                currentPDFPage++;
+                renderPDFPage(currentPDFPage);
+            }
+        }
+        function prevPDFPage() {
+            if (currentPDFPage > 1) {
+                currentPDFPage--;
+                renderPDFPage(currentPDFPage);
+            }
+        }
+        function updatePDFPageIndicator() {
+            if (pageIndicator) pageIndicator.textContent = `${currentPDFPage} / ${totalPDFPages}`;
+        }
+        function hidePDFControls() {
+            if (pdfControls) pdfControls.style.display = 'none';
+        }
         function showContent() {
             dropZone.classList.add('has-content'); contentArea.classList.add('has-content');
         }
         function clearContent() {
             contentArea.innerHTML = ''; contentArea.classList.remove('has-content'); dropZone.classList.remove('has-content');
             clearAllCalipers();
+            pdfDoc = null; currentPDFPage = 1; totalPDFPages = 0; hidePDFControls();
         }
 
         document.querySelectorAll('.color-option').forEach(option => {

--- a/style.css
+++ b/style.css
@@ -225,3 +225,20 @@ body {
     text-decoration: underline;
     color: #8C1515;
 }
+
+.pdf-controls {
+    position: absolute;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: none;
+    align-items: center;
+    gap: 10px;
+    z-index: 1600;
+}
+
+#pageIndicator {
+    font-size: 14px;
+    font-weight: bold;
+    color: #333;
+}


### PR DESCRIPTION
## Summary
- allow PDF uploads alongside images and text
- add pdf.js dependency and navigation controls
- render PDFs page by page and reset calipers when switching pages

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_68428842b22c8324aff949d622cebba9